### PR TITLE
Fix missing bio_new

### DIFF
--- a/spec/rsa_spec.cr
+++ b/spec/rsa_spec.cr
@@ -6,14 +6,14 @@ require "../src/openssl_ext/rsa"
 describe OpenSSL::RSA do
   describe "instantiating and generate a key" do
     it "can instantiate and generate for a given key size" do
-      pkey = OpenSSL::RSA.new(256)
+      pkey = OpenSSL::RSA.new(512)
       pkey.private?.should be_true
       pkey.public?.should be_false
 
       pkey.public_key.public?.should be_true
     end
     it "can export to PEM format" do
-      pkey = OpenSSL::RSA.new(256)
+      pkey = OpenSSL::RSA.new(512)
       pkey.private?.should be_true
 
       pem = pkey.to_pem
@@ -23,7 +23,7 @@ describe OpenSSL::RSA do
       isEmpty.should be_false
     end
     it "can export to DER format" do
-      pkey = OpenSSL::RSA.new(256)
+      pkey = OpenSSL::RSA.new(512)
       pkey.private?.should be_true
       pem = pkey.to_pem
       der = pkey.to_der
@@ -97,13 +97,13 @@ k0LaJjYM2ycehinmuLHgY3qdDJgtEbt4WG5XNQzhyfaN
   end
   describe "RSA-blinding" do
     it "can turn blinding on" do
-      rsa = OpenSSL::RSA.new(128)
+      rsa = OpenSSL::RSA.new(512)
       rsa.blinding_on!
 
       rsa.blinding_on?.should be_true
     end
     it "can turn blinding off" do
-      rsa = OpenSSL::RSA.new(128)
+      rsa = OpenSSL::RSA.new(512)
       rsa.blinding_on!
       rsa.blinding_off!
 
@@ -112,14 +112,14 @@ k0LaJjYM2ycehinmuLHgY3qdDJgtEbt4WG5XNQzhyfaN
   end
   describe "encrypting / decrypting" do
     it "can encrypt a string using its private key and decrypt with public key" do
-      rsa = OpenSSL::RSA.new(256)
+      rsa = OpenSSL::RSA.new(512)
       encrypted = rsa.private_encrypt "hello world"
       decrypted = rsa.public_decrypt encrypted
 
       String.new(decrypted).should eq "hello world"
     end
     it "can encrypt a string using its public key and decrypt with private key" do
-      rsa = OpenSSL::RSA.new(256)
+      rsa = OpenSSL::RSA.new(512)
       encrypted = rsa.public_encrypt "hello world"
       decrypted = rsa.private_decrypt encrypted
 

--- a/src/openssl_ext/bio.cr
+++ b/src/openssl_ext/bio.cr
@@ -16,7 +16,8 @@ struct OpenSSL::GETS_BIO
       io.seek(position)
       bytes = io.read(Slice.new(buffer, line.bytesize)).to_i
 
-      bytes - 1
+      bytes -= 1 unless bytes == 1
+      bytes
     end
     {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
       LibCrypto.BIO_meth_set_gets(crystal_bio, bgets)

--- a/src/openssl_ext/bio.cr
+++ b/src/openssl_ext/bio.cr
@@ -1,8 +1,8 @@
 struct OpenSSL::GETS_BIO
   GETS_BIO = begin
     crystal_bio = OpenSSL::BIO::CRYSTAL_BIO
-    crystal_bio.bgets = LibCrypto::BioMethodGets.new do |bio, buffer, len|
-      io = Box(IO).unbox(bio.value.ptr)
+    bgets = LibCrypto::BioMethodGets.new do |bio, buffer, len|
+      io = Box(IO).unbox(BIO.get_data(bio))
       io.flush
 
       position = io.pos
@@ -18,19 +18,25 @@ struct OpenSSL::GETS_BIO
 
       bytes - 1
     end
+    {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
+      LibCrypto.BIO_meth_set_gets(crystal_bio, bgets)
+    {% else %}
+      crystal_bio.value.bgets = bgets
+    {% end %}
     crystal_bio
   end
 
   @boxed_io : Void*
 
   def initialize(@io : IO)
-    @bio = LibCrypto.bio_new(pointerof(GETS_BIO))
+    @bio = LibCrypto.BIO_new(GETS_BIO)
 
     # We need to store a reference to the box because it's
     # stored in `@bio.value.ptr`, but that lives in C-land,
     # not in Crystal-land.
     @boxed_io = Box(IO).box(io)
-    @bio.value.ptr = @boxed_io
+
+    BIO.set_data(@bio, @boxed_io)
   end
 
   getter io


### PR DESCRIPTION
- Resolve errors related to 'bio_new' occurring in crystal 0.27.0

Fixes #2 