### PR TITLE
Small fixes

### DIFF
--- a/src/openssl_ext/pkey.cr
+++ b/src/openssl_ext/pkey.cr
@@ -127,7 +127,7 @@ module OpenSSL
           len = key_size
         end
 
-        buffer.copy_from(pwd.to_slice.pointer(len), len)
+        buffer.copy_from(pwd.to_slice.to_unsafe, len)
 
         return len
       }

--- a/src/openssl_ext/rsa.cr
+++ b/src/openssl_ext/rsa.cr
@@ -1,5 +1,6 @@
 require "big"
 require "./pkey"
+require "./lib_crypto"
 
 module OpenSSL
   class RSA < PKey


### PR DESCRIPTION
Found that without the include, it was using crystal's own LibCrypto.

the `slice.pointer` does not exist anymore https://github.com/crystal-lang/crystal/pull/7581